### PR TITLE
mcuxsdk: enet: fsl_enet: avoid possible race condition on timestamp

### DIFF
--- a/drivers/enet/fsl_enet.c
+++ b/drivers/enet/fsl_enet.c
@@ -2995,7 +2995,7 @@ void ENET_Ptp1588GetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_
     ENET_Ptp1588GetTimerNoIrqDisable(base, handle, ptpTime);
 
     /* Get PTP timer wrap event. */
-    if (0U != (base->EIR & (uint32_t)kENET_TsTimerInterrupt))
+    if (0U != (base->EIR & (uint32_t)kENET_TsTimerInterrupt) && ptpTime->nanosecond < (ENET_NANOSECOND_ONE_SECOND / 2))
     {
         ptpTime->second++;
     }


### PR DESCRIPTION
Only correct second value if the nanosecond has reasonably value.

Describe the pull request
The K64 has only nanoseconds part of the second timer.
Second and nanosecond can not be captured at the same time.

If the nanoseconds are close to the overflow care should be taken.

The second correction should be applied if

    after the copy of the second value and
    before the capture of the nanoseconds part
    an overflow of the nanoseconds happened.
    The nanosecond value is small and the second value must be incremented.

if the overflow happend

    after the capture of the nanoseconds
    but early enough that the ISR is asserted when checking
    no second increment should be performed.
    The nanosecond value is high and the second value must NOT be touched.

my setup is:
- FRDM_K64F
- Zephyr SDK 17.0 gcc 12.2

