### PR TITLE
Fix LPSPI_MasterInit to enable LPSPI after setting delay times

### DIFF
--- a/drivers/lpspi/fsl_lpspi.c
+++ b/drivers/lpspi/fsl_lpspi.c
@@ -337,13 +337,13 @@ void LPSPI_MasterInit(LPSPI_Type *base, const lpspi_master_config_t *masterConfi
                 LPSPI_TCR_LSBF(masterConfig->direction) | LPSPI_TCR_FRAMESZ(masterConfig->bitsPerFrame - 1U) |
                 LPSPI_TCR_PRESCALE(tcrPrescaleValue) | LPSPI_TCR_PCS(masterConfig->whichPcs);
 
-    LPSPI_Enable(base, true);
-
     (void)LPSPI_MasterSetDelayTimes(base, masterConfig->pcsToSckDelayInNanoSec, kLPSPI_PcsToSck, srcClock_Hz);
     (void)LPSPI_MasterSetDelayTimes(base, masterConfig->lastSckToPcsDelayInNanoSec, kLPSPI_LastSckToPcs, srcClock_Hz);
     (void)LPSPI_MasterSetDelayTimes(base, masterConfig->betweenTransferDelayInNanoSec, kLPSPI_BetweenTransfer,
                                     srcClock_Hz);
 
+    LPSPI_Enable(base, true);
+    
     LPSPI_SetDummyData(base, LPSPI_DUMMY_DATA);
 }
 


### PR DESCRIPTION
LPSPI_MasterSetDelayTimes clearly states that module must be disabled to change the delay values. This corresponds to the information in the data sheet.