### PR TITLE
Fix fsl_common_arm.c compilation fails on IAR EWARM

### DIFF
--- a/drivers/common/fsl_common_arm.c
+++ b/drivers/common/fsl_common_arm.c
@@ -181,15 +181,22 @@ static void DelayLoop(uint32_t count)
 {
     __ASM volatile("    MOV    R0, %0" : : "r"(count));
     __ASM volatile(
+#if defined(__ICCARM__)
+        "loop:                          \n"
+#else
         "loop%=:                        \n"
+#endif
 #if defined(__GNUC__) && !defined(__ARMCC_VERSION)
         "    SUB    R0, R0, #1          \n"
 #else
         "    SUBS   R0, R0, #1          \n"
 #endif
         "    CMP    R0, #0              \n"
-
+#if defined(__ICCARM__)
+        "    BNE    loop                \n"
+#else
         "    BNE    loop%=              \n"
+#endif
         :
         :
         : "r0");


### PR DESCRIPTION
### Prerequisites

- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

### Describe the pull request

Add #if to avoid GNU local-label syntax when using IAR compiler. Fixes #15.

Note that this change reverts a portion of https://github.com/nxp-mcuxpresso/mcux-sdk/pull/166 when compiling with IAR compiler. This is appropriate because the IAR assembler explicitly specifies that labels defined in an inline assembler statement will be local to that statement.  (IAR C/C++ Development Guide, DARM-25, p166)

### Type of change

Bug fix (non-breaking change which fixes an issue)

### Tests

**Test configuration (please complete the following information):**
* IDE: IAR Embedded Workbench IDE - Arm 8.50.9
* Compiler: IAR ANSI C/C++ Compiler V8.50.9.278/W32 for ARM
* Operating system: Windows 11

**Test executed**
* Built and ran application on target

