### PR TITLE
enet: fsl_enet: Add Relative Clock Jump

### DIFF
--- a/drivers/enet/fsl_enet.h
+++ b/drivers/enet/fsl_enet.h
@@ -1963,6 +1963,18 @@ void ENET_Ptp1588GetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_
 void ENET_Ptp1588SetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_t *ptpTime);
 
 /*!
+ * @brief Adjusts the ENET PTP 1588 timer by jumping a relative time difference.
+ *
+ * Compared to ENET_Ptp1588SetTimer, this function yields more accurate results when
+ * the relative time difference between the PTP clock and the target clock is known
+ * (e.g., through a capture event retrieved by ENET_Ptp1588GetChannelCaptureValue).
+ *
+ * @param base  ENET peripheral base address.
+ * @param nanosecondDiff The offset that is added/subtracted from the current PTP time
+ */
+void ENET_Ptp1588JumpTimer(ENET_Type *base, int64_t nanosecondDiff);
+
+/*!
  * @brief The IEEE 1588 PTP time stamp interrupt handler.
  *
  * @param base  ENET peripheral base address.


### PR DESCRIPTION
While ENET_Ptp1588SetTimer provides a mechanism to set the clock to an absolute time value, this often introduces additional software delays. In contrast, ENET_Ptp1588JumpTimer uses a relative offset in case we already have to hardware timestamps.

The main motivation for this extension is to avoid usages like [here](https://github.com/zephyrproject-rtos/zephyr/blob/ccaaaabba2611b85f62c9dc6e7dbabd7542bce3b/subsys/net/lib/ptp/clock.c#L544), where both ingress and egress timestamps are given (hence the relative error is known) but one still has to perform a `ptp_clock_get`and `ptp_clock_set`.

Moreover, this can drastically improve the accuracy when aiming to synchronize with a 1PPS signal (e.g., generated by a GNSS module). 
```c
/** Adjust the PTP clock by jumping (if the difference exceeds a configured
 * threshold) or by increasing/decreasing the clock rate. */
static void synchronize(uint64_t ingress, uint64_t egress) {
  int64_t offset =
      (int64_t)(ingress - (int64_t)CONFIG_PTP_INGRESS_LATENCY - egress);

  /* If diff is too big, ptp_clk needs to be set first. */
  if ((offset > (int64_t)CONFIG_PTP_SYNC_JUMP_THRES) ||
      (offset < -(int64_t)CONFIG_PTP_SYNC_JUMP_THRES)) {
    LOG_WRN("Clock offset exceeds jump threshold: %lldns", offset);
    ptp_clock_jump(PTP_CLOCK, (int32_t)offset);
    return;
  }

  double ppb = ptp_clock_servo_pi(offset);
  ptp_clock_rate_adjust(PTP_CLOCK, 1.0 + (ppb / 1000000000.0));
}

static void ptp_clock_synchronize_pps(uint32_t tm) {
  if (tm % NSEC_PER_SEC > 500 * NSEC_PER_MSEC) {
    LOG_INF("offset: %d ns", (int)(tm % NSEC_PER_SEC) - NSEC_PER_SEC);
    synchronize(NSEC_PER_SEC, tm % NSEC_PER_SEC);
  } else {
    LOG_INF("offset: %u ns", tm % NSEC_PER_SEC);
    synchronize(0, tm % NSEC_PER_SEC);
  }
}

// ...
// e.g., register ptp_clock_synchronize_pps as IRQ for ENET_1588_EVENT_IN
```

For the IMXRT1060, `ENET_Ptp1588JumpTimer` yielded an accuracy in the range of  < 12us, whereas the analogous approach from [the previous example](https://github.com/zephyrproject-rtos/zephyr/blob/ccaaaabba2611b85f62c9dc6e7dbabd7542bce3b/subsys/net/lib/ptp/clock.c#L544) often yielded clock skews > 100ms. Latter is especially critical as subsequent rate adjustments are often done without validation (e.g., as described in this [issue](https://github.com/zephyrproject-rtos/zephyr/issues/93804)).

Also, for completeness, the implementation was tested via the following code snippet:
```c
#include <assert.h>
#include <stdbool.h>
#include <stdint.h>

struct _ptp_time {
  uint32_t ATVR;
  uint64_t msTimerSecond;
};
typedef struct _ptp_time ptp_time;

#define ENET_NANOSECOND_ONE_SECOND 1000000000U

#define DIV_FLOOR(x, y)                                                        \
  (((x) >= 0 || (x) % (y) == 0) ? (x) / (y) : (x) / (y) - 1)

void ENET_Ptp1588JumpTimer(ptp_time time, int64_t diffNanosecond,
                           uint64_t expected_msTimerSecond,
                           uint32_t expected_ATVR, bool expected_abort) {

  /* Adjust msTimerSecond under account of potential over-/underflow of ATVR.
   * Note that, compared to integer division that round towards zero, we require
   * a floor division in the case of underflows */
  int32_t timeNanosecond = time.ATVR % ENET_NANOSECOND_ONE_SECOND;
  int64_t diffSecond =
      DIV_FLOOR(diffNanosecond + timeNanosecond, ENET_NANOSECOND_ONE_SECOND);
  if ((int64_t)time.msTimerSecond < -diffSecond) {
    assert(expected_abort);
    return;
  }
  time.msTimerSecond += diffSecond;

  /* Adjust ATVR for nanosecond counter. Note that simply doing
   * timeNanosecond % ENET_NANOSECOND_ONE_SECOND
   * could resuld in a underflow if diffNanosecond is negative. */
  timeNanosecond += diffNanosecond % ENET_NANOSECOND_ONE_SECOND;
  time.ATVR = (timeNanosecond + ENET_NANOSECOND_ONE_SECOND) %
              ENET_NANOSECOND_ONE_SECOND;

  assert(expected_ATVR == time.ATVR &&
         expected_msTimerSecond == time.msTimerSecond);
}

int main() {
  ptp_time time = {100000000, 5}; // 5.1s

  // positive difference (no second overflow): 5.1s + 0.2s = 5.3s
  ENET_Ptp1588JumpTimer(time, 200000000, 5, 300000000, false);
  // positive difference (1 second overflow): 5.1s + 0.95s = 6.05s
  ENET_Ptp1588JumpTimer(time, 950000000, 6, 50000000, false);
  // positive difference (2 second overflow): 5.1s + 0.95s = 6.05s
  ENET_Ptp1588JumpTimer(time, 1950000000, 7, 50000000, false);
  // negative difference (no second underflow): 5.1s - 0.05s = 5.05s
  ENET_Ptp1588JumpTimer(time, -50000000, 5, 50000000, false);
  // negative difference (1 second underflow): 5.1s - 0.25s = 4.85s
  ENET_Ptp1588JumpTimer(time, -250000000, 4, 850000000, false);
  // negative difference (2 second underflow): 5.1s - 0.25s = 4.85s
  ENET_Ptp1588JumpTimer(time, -1250000000, 3, 850000000, false);
  // negative difference (2 second underflow): 5.1s - 0.25s = 4.85s
  ENET_Ptp1588JumpTimer(time, -1250000000, 3, 850000000, false);
  // no negative seconds
  ENET_Ptp1588JumpTimer(time, -7000000000, 0, 0, true);

  return 0;
}
```

I'm of course happy to extend the proposed functionality if you have further suggestions. 