### PR TITLE
drivers: usdhc: don't invalidate cache on non-blocking non-DMA transfer

### DIFF
--- a/drivers/usdhc/fsl_usdhc.c
+++ b/drivers/usdhc/fsl_usdhc.c
@@ -1851,6 +1851,8 @@ status_t USDHC_TransferScatterGatherADMANonBlocking(USDHC_Type *base,
         USDHC_EnableInterruptSignal(base, kUSDHC_CommandFlag);
     }
 
+    handle->enDMA = enDMA;
+
     /* send command first */
     USDHC_SendCommand(base, command);
 
@@ -1981,6 +1983,8 @@ status_t USDHC_TransferNonBlocking(USDHC_Type *base,
         USDHC_ClearInterruptStatusFlags(base, kUSDHC_CommandFlag);
         USDHC_EnableInterruptSignal(base, kUSDHC_CommandFlag);
     }
+
+    handle->enDMA = enDMA;
 
     /* send command first */
     USDHC_SendCommand(base, command);
@@ -2298,7 +2302,7 @@ static void USDHC_TransferHandleData(USDHC_Type *base, usdhc_handle_t *handle, u
                 transferStatus = kStatus_USDHC_TransferDataComplete;
 
 #if defined(FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL) && FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL
-                if (handle->data->dataDirection == kUSDHC_TransferDirectionReceive)
+                if (handle->enDMA && handle->data->dataDirection == kUSDHC_TransferDirectionReceive)
                 {
                     usdhc_scatter_gather_data_list_t *sgDataList = &handle->data->sgData;
                     while (sgDataList != NULL)
@@ -2365,7 +2369,7 @@ static void USDHC_TransferHandleData(USDHC_Type *base, usdhc_handle_t *handle, u
                 transferStatus = kStatus_USDHC_TransferDataComplete;
 
 #if defined(FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL) && FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL
-                if (handle->data->rxData != NULL)
+                if (handle->enDMA && handle->data->rxData != NULL)
                 {
                     DCACHE_InvalidateByRange((uintptr_t)(handle->data->rxData),
                                              (handle->data->blockSize) * (handle->data->blockCount));

--- a/drivers/usdhc/fsl_usdhc.h
+++ b/drivers/usdhc/fsl_usdhc.h
@@ -763,6 +763,8 @@ struct _usdhc_handle
 
     usdhc_transfer_callback_t callback; /*!< Callback function. */
     void *userData;                     /*!< Parameter for transfer complete callback. */
+
+    bool enDMA;                         /*!< Transfer parameter. Was DMA used? */
 };
 
 /*! @brief USDHC transfer function. */


### PR DESCRIPTION
In `USDHC_TransferNonBlocking()`, DMA may be disabled if the user passes a NULL `dmaConfig` or if `USDHC_SetAdmaTableConfig()` fails. In that case, `USDHC_TransferNonBlocking()` correctly skips its cache clean, but `USDHC_TransferHandleData()` doesn't skip its cache invalidate, meaning it replaces the entire data buffer's cache line with stale data from RAM. This memory corruption causes undefined behavior and system instability.

Fix the issue by remembering if we used DMA and only invalidating the cache if we did. This matches the behavior of `USDHC_TransferBlocking()`. Also fix `USDHC_TransferScatterGatherADMANonBlocking()`.

Memory corruption may still occur if the DMA buffer shares a cache line with unrelated data that the CPU updates during a transfer, but there is no way for us to detect that in the SDK. The user should avoid that situation.

Fixes #20